### PR TITLE
ThemePicker: Grant missing wallpaper permissions

### DIFF
--- a/privapp_whitelist_com.android.wallpaper.xml
+++ b/privapp_whitelist_com.android.wallpaper.xml
@@ -16,7 +16,9 @@
   -->
 <permissions>
     <privapp-permissions package="com.android.wallpaper">
+        <permission name="android.permission.BIND_WALLPAPER"/>
         <permission name="android.permission.CHANGE_OVERLAY_PACKAGES"/>
+        <permission name="android.permission.READ_WALLPAPER_INTERNAL"/>
         <permission name="android.permission.SET_WALLPAPER_COMPONENT"/>
         <permission name="android.permission.WRITE_SECURE_SETTINGS"/>
     </privapp-permissions>


### PR DESCRIPTION
Some wallpaper-related permissions necessary for launcher previews (and
possibly some other functionality) are missing here. Grant the missing
permissions to fix launcher preview rendering.

Change-Id: I177b0a6e58ffc50d0c3fa76a0137d3bdb7d63d11